### PR TITLE
Removing unnecessary columns

### DIFF
--- a/data/scripts/planilha_projetos.sql
+++ b/data/scripts/planilha_projetos.sql
@@ -1,3 +1,15 @@
-SELECT projetos.AnoProjeto + projetos.Sequencial as PRONAC, *
-FROM SAC.dbo.Projetos projetos
+SELECT projetos.AnoProjeto + projetos.Sequencial as PRONAC,
+idPRONAC,
+UfProjeto,
+Area,
+Segmento,
+NomeProjeto,
+CgcCpf,
+Situacao,
+DtProtocolo,
+DtSituacao,
+DtInicioExecucao,
+DtFimExecucao
+FROM SAC.dbo.Projetos
 ;
+


### PR DESCRIPTION
Removes unnecessary columns.

The dataset `planilha_projetos.csv` contains unnecessary columns, i.e columns that are not being used by the package `salic-ml`. The column `ResumoProjeto`, which is unnecessary, contains a special character `\r` that pandas `to_csv` and `read_csv` is having trouble dealing with.