### PR TITLE
Reconfigura cronjob com os comandos inv

### DIFF
--- a/etc/scripts/crontab
+++ b/etc/scripts/crontab
@@ -1,1 +1,1 @@
-59 23 * * SUN sh /salic_ml_web/preload_data.sh >> /var/log/cron_complexity.log 2>&1
+59 23 * * SUN sh etc/scripts/preload_data.sh >> /var/log/cron_complexity.log 2>&1

--- a/etc/scripts/preload_data.sh
+++ b/etc/scripts/preload_data.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 echo "Attempting to cron"
-python3 /api/manage.py shell < /salic_ml_web/preload_data.py
+inv update-data --pickles
+inv update-models train-metrics
+


### PR DESCRIPTION
Antes, o cronjob não executava os comandos inv para recalcular as métricas. Modificou-se os comandos para funcionarem com a nova implementação.