### PR TITLE
[REVIEW] Correção no cronjob de cálculo das métricas

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,8 @@ ADD etc/scripts/crontab /etc/cron.d/complexity-cron
 
 LABEL com.centurylinklabs.watchtower.enable="true"
 
+RUN touch /var/log/test_log.log
+
 RUN chmod 0644 /etc/cron.d/complexity-cron && \
         touch /var/log/cron_complexity.log && \
         crontab /etc/cron.d/complexity-cron

--- a/etc/scripts/crontab
+++ b/etc/scripts/crontab
@@ -1,1 +1,2 @@
 59 23 * * SUN sh /etc/scripts/preload_data.sh >> /var/log/cron_complexity.log 2>&1
+* * * * * echo "Testing cronjob log: [$(date)]" >> /var/log/test_log.log 2>&1

--- a/tasks.py
+++ b/tasks.py
@@ -29,6 +29,7 @@ def run(ctx):
     """
     Run development server
     """
+    os.system('service cron start')
     manage(ctx, 'runserver 0.0.0.0:8000', env={})
 
 


### PR DESCRIPTION
Discussão em: https://github.com/lappis-unb/salic-ml/issues/385

A solução final foi iniciar o serviço cron junto com o servidor.